### PR TITLE
AFK message sender

### DIFF
--- a/AFKmessage.lua
+++ b/AFKmessage.lua
@@ -1,0 +1,11 @@
+name = "AFK message sender"
+description = "Sends a message in Hive chat when you are afk kicked, useful for party chat"
+
+customResponse = settings.addTextBox("Custom Response", "Message to send when AFK-kicked, default is 'AFK, will be back!'", "AFK, will be back!", 100)
+
+onEvent("ChatReceiveEvent", function(message, name, type)
+    if message:find("You were removed from the game due to inactivity!") then
+        local response = customResponse.value ~= "" and customResponse.value or "AFK, will be back!"
+        player.say(response)
+    end
+end)


### PR DESCRIPTION
Automatically sends an AFK message when you are AFK kicked in Hive, it can be useful in party chat. By default the message is set to "AFK, will be back!", However, You can customise it under settings.  


created by - @s6iy
![Screenshot 2025-04-05 140404](https://github.com/user-attachments/assets/4614e6d6-a949-4fd9-a8c2-0f7cf8166c78)
